### PR TITLE
audio does not exist fix (after youtube update)

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -248,7 +248,7 @@ function createSyncAudioElement(url)
 	const videoElement = window.document.getElementsByTagName('video')[0];
 	if(!videoElement.paused) { syncAudioElement.play(); }
 
-	document.getElementById('player').appendChild(syncAudioElement);
+  document.body.append(syncAudioElement)
 }
 
 function changeRateAudio(event){


### PR DESCRIPTION
Because i am a smart speaker user, and I couldn't stand delayed youtube, I decided to try to fix this extension.

Issue was with nonexisting audio element which is destroyed when youtube loads.
I changed syncAudio element location to body, and it seems working now.